### PR TITLE
refactor(leadform): centralize status messaging in shell; remove Step…

### DIFF
--- a/app/hosts/page.js
+++ b/app/hosts/page.js
@@ -150,7 +150,7 @@ export default function HostsPage() {
           We’ll follow up with next steps.
         </p>
         <div className="mt-4">
-          <LeadForm type="host" />
+          <LeadForm defaultRole="host" pageSource="hosts" />
         </div>
       </section>
     </div>

--- a/app/page.js
+++ b/app/page.js
@@ -265,7 +265,7 @@ export default function HomePage() {
           soon.
         </p>
 
-        <LeadForm />
+        <LeadForm defaultRole="host" pageSource="landing" />
       </section>
     </div>
   );

--- a/app/renters/page.js
+++ b/app/renters/page.js
@@ -4,33 +4,59 @@ import SeoJsonLd from "@/components/SeoJsonLd";
 import { faqJsonLd } from "@/lib/seo";
 
 const renterFaq = [
-  { q: "Minimum age and ID?", a: "Minimum age 21 (example). Valid license and ID verification required." },
-  { q: "Deposit release timing?", a: "Temporary hold (e.g., $200–$300) released after return if no issues." },
-  { q: "Can I extend my trip?", a: "Yes, if the car’s available. Request in advance." },
-  { q: "Mileage limits?", a: "Shown on each listing; confirm with the host if unsure." },
-  { q: "Fuel & cleaning policy?", a: "Return with the same fuel level and reasonable cleanliness." },
+  {
+    q: "Minimum age and ID?",
+    a: "Minimum age 21 (example). Valid license and ID verification required.",
+  },
+  {
+    q: "Deposit release timing?",
+    a: "Temporary hold (e.g., $200–$300) released after return if no issues.",
+  },
+  {
+    q: "Can I extend my trip?",
+    a: "Yes, if the car’s available. Request in advance.",
+  },
+  {
+    q: "Mileage limits?",
+    a: "Shown on each listing; confirm with the host if unsure.",
+  },
+  {
+    q: "Fuel & cleaning policy?",
+    a: "Return with the same fuel level and reasonable cleanliness.",
+  },
 ];
 
 export const metadata = {
   title: "For Renters | FR",
-  description: "Skip the counter. Book local, verified cars. Requirements, pricing, and pickup walkthrough.",
+  description:
+    "Skip the counter. Book local, verified cars. Requirements, pricing, and pickup walkthrough.",
 };
 
 export default function RentersPage() {
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">
-      <h1 className="text-3xl font-bold text-gray-900">Skip the counter. Book local, verified cars.</h1>
-      <p className="mt-2 text-gray-700">Simple requirements, transparent pricing, and quick pickup.</p>
+      <h1 className="text-3xl font-bold text-gray-900">
+        Skip the counter. Book local, verified cars.
+      </h1>
+      <p className="mt-2 text-gray-700">
+        Simple requirements, transparent pricing, and quick pickup.
+      </p>
 
       {/* Requirements */}
       <section className="mt-8 grid gap-6 md:grid-cols-4">
         {[
           { t: "Valid license", d: "U.S. driver’s license—unexpired." },
           { t: "ID verification", d: "Government ID & selfie check." },
-          { t: "Refundable hold", d: "Temporary deposit hold during the trip." },
+          {
+            t: "Refundable hold",
+            d: "Temporary deposit hold during the trip.",
+          },
           { t: "Major card", d: "Visa, Mastercard, etc." },
         ].map((c, i) => (
-          <div key={i} className="rounded-lg border border-gray-200 bg-white p-4 shadow-card">
+          <div
+            key={i}
+            className="rounded-lg border border-gray-200 bg-white p-4 shadow-card"
+          >
             <h3 className="font-semibold text-gray-900">{c.t}</h3>
             <p className="mt-1 text-sm text-gray-700">{c.d}</p>
           </div>
@@ -39,7 +65,9 @@ export default function RentersPage() {
 
       {/* Pricing overview */}
       <section className="mt-10">
-        <h2 className="text-xl font-semibold text-gray-900">Pricing (example)</h2>
+        <h2 className="text-xl font-semibold text-gray-900">
+          Pricing (example)
+        </h2>
         <ul className="mt-3 list-disc pl-5 text-sm text-gray-800">
           <li>Daily rate set by host (varies by car and date)</li>
           <li>Service fee ~10% (processing & support)</li>
@@ -52,12 +80,26 @@ export default function RentersPage() {
         <h2 className="text-xl font-semibold text-gray-900">Pickup & return</h2>
         <div className="mt-3 grid gap-4 md:grid-cols-3">
           {[
-            { t: "Meet at a public spot", d: "Garage or lot chosen by your host." },
-            { t: "Quick verification", d: "Show your verified ID and do a few photos." },
-            { t: "Return & confirm", d: "Fuel, odometer, exterior pics—then handoff." },
+            {
+              t: "Meet at a public spot",
+              d: "Garage or lot chosen by your host.",
+            },
+            {
+              t: "Quick verification",
+              d: "Show your verified ID and do a few photos.",
+            },
+            {
+              t: "Return & confirm",
+              d: "Fuel, odometer, exterior pics—then handoff.",
+            },
           ].map((s, i) => (
-            <div key={i} className="rounded-lg border border-gray-200 bg-white p-4 shadow-card">
-              <div className="text-xs font-semibold text-brand-700">Step {i + 1}</div>
+            <div
+              key={i}
+              className="rounded-lg border border-gray-200 bg-white p-4 shadow-card"
+            >
+              <div className="text-xs font-semibold text-brand-700">
+                Step {i + 1}
+              </div>
               <div className="mt-1 font-medium text-gray-900">{s.t}</div>
               <div className="mt-1 text-sm text-gray-700">{s.d}</div>
             </div>
@@ -76,10 +118,14 @@ export default function RentersPage() {
 
       {/* Waitlist form */}
       <section className="mt-10 max-w-xl">
-        <h2 className="text-xl font-semibold text-gray-900">Join the waitlist</h2>
-        <p className="mt-1 text-sm text-gray-700">We’ll notify you when cars are available in your area.</p>
+        <h2 className="text-xl font-semibold text-gray-900">
+          Join the waitlist
+        </h2>
+        <p className="mt-1 text-sm text-gray-700">
+          We’ll notify you when cars are available in your area.
+        </p>
         <div className="mt-4">
-          <LeadForm type="renter" />
+          <LeadForm defaultRole="renter" pageSource="renters" />
         </div>
       </section>
     </div>

--- a/components/forms/Step1Quick.js
+++ b/components/forms/Step1Quick.js
@@ -1,0 +1,116 @@
+// components/forms/Step1Quick.jsx
+"use client";
+import { useRef } from "react";
+import Button from "../ui/Button";
+
+export default function Step1Quick({
+  role,            // 'host' | 'renter' | 'both'
+  setRole,
+  onSubmit,
+  loading,
+}) {
+  const formRef = useRef(null);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    // Honeypot quick bail on client
+    if (fd.get("website")) {
+      // pretend success to bots
+      onSubmit({
+        firstName: "Bot",
+        email: "bot@example.com",
+        phone: "",
+        cityOrZip: "",
+        consent: true,
+        honeypot: "1",
+      });
+      return;
+    }
+    onSubmit({
+      firstName: fd.get("firstName"),
+      email: fd.get("email"),
+      phone: fd.get("phone"),
+      cityOrZip: fd.get("cityOrZip"),
+      consent: fd.get("consent") === "on",
+      honeypot: fd.get("website") || "",
+    });
+    try { formRef.current?.reset(); } catch {}
+  }
+
+  return (
+    <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
+      {/* name / email */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label className="block text-sm text-gray-700">First name *</label>
+          <input name="firstName" required className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">Email *</label>
+          <input type="email" name="email" required className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+        </div>
+      </div>
+
+      {/* phone */}
+      <div>
+        <label className="block text-sm text-gray-700">Phone (optional)</label>
+        <input name="phone" className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+      </div>
+
+      {/* city or zip */}
+      <div>
+        <label className="block text-sm text-gray-700">City or ZIP *</label>
+        <input
+          name="cityOrZip"
+          required
+          placeholder="Lincoln, NE or 68508"
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+        />
+      </div>
+
+      {/* role picker */}
+      <fieldset className="mt-1">
+        <legend className="block text-sm text-gray-700">I’m interested as *</legend>
+        <div className="mt-2 flex flex-wrap gap-3">
+          {[
+            { value: "host", label: "Host" },
+            { value: "renter", label: "Renter" },
+            { value: "both", label: "Both" },
+          ].map((opt) => (
+            <label key={opt.value} className="inline-flex items-center gap-2 text-sm text-gray-800">
+              <input
+                type="radio"
+                name="role"
+                value={opt.value}
+                checked={role === opt.value}
+                onChange={() => setRole(opt.value)}
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* consent */}
+      <div className="flex items-center gap-2">
+        <input id="consent" name="consent" type="checkbox" required className="h-4 w-4" />
+        <label htmlFor="consent" className="text-sm text-gray-700">
+          I agree to be contacted about FR. <a href="/legal/privacy" className="underline">Privacy Policy</a>
+        </label>
+      </div>
+
+      {/* Honeypot */}
+      <div className="hp-hidden" aria-hidden="true">
+        <label>Website</label>
+        <input name="website" tabIndex={-1} autoComplete="off" />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" variant="primary" disabled={loading}>
+          {loading ? "Submitting…" : "Join early access"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/forms/Step2Host.js
+++ b/components/forms/Step2Host.js
@@ -1,0 +1,313 @@
+// components/forms/Step2Host.jsx
+"use client";
+import { useState } from "react";
+import Button from "../ui/Button";
+
+export default function Step2Host({ onSubmit, loading, savedAt }) {
+  const [rows, setRows] = useState([
+    {
+      year: "",
+      make: "",
+      model: "",
+      bodyType: "Sedan",
+      seats: "5",
+      transmission: "Auto",
+      mileageBand: "<50k",
+      availability: "Both",
+      readiness: "Ready now",
+    },
+  ]);
+  const [meta, setMeta] = useState({
+    city: "",
+    state: "",
+    zip5: "",
+    insuranceStatus: "unsure",
+    handoff: "both",
+    pricingExpectation: "",
+    fleetSize: "1",
+    notes: "",
+  });
+
+  function addRow() {
+    setRows((r) => [
+      ...r,
+      {
+        year: "",
+        make: "",
+        model: "",
+        bodyType: "Sedan",
+        seats: "5",
+        transmission: "Auto",
+        mileageBand: "<50k",
+        availability: "Both",
+        readiness: "Ready now",
+      },
+    ]);
+  }
+  function removeRow(i) {
+    setRows((r) => r.filter((_, idx) => idx !== i));
+  }
+  function updateRow(i, k, v) {
+    setRows((r) => r.map((row, idx) => (idx === i ? { ...row, [k]: v } : row)));
+  }
+
+  function handleSave(e) {
+    e.preventDefault();
+    const vehicles = rows.map((r) => ({
+      year: r.year?.trim(),
+      make: r.make?.trim(),
+      model: r.model?.trim(),
+      bodyType: r.bodyType,
+      seats: Number(r.seats || 0),
+      transmission: r.transmission,
+      mileageBand: r.mileageBand,
+      availability: r.availability,
+      readiness: r.readiness,
+    }));
+    onSubmit({
+      locations:
+        meta.city || meta.zip5
+          ? [
+              {
+                city: meta.city || undefined,
+                state: meta.state || undefined,
+                zip5: meta.zip5 || undefined,
+              },
+            ]
+          : [],
+      vehicles,
+      insuranceStatus: meta.insuranceStatus,
+      handoff: meta.handoff,
+      pricingExpectation: meta.pricingExpectation?.trim() || undefined,
+      fleetSize: meta.fleetSize,
+      notes: meta.notes?.trim() || undefined,
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="rounded-lg border border-gray-200 p-4"
+    >
+      <h3 className="text-lg font-semibold text-gray-900">Host details</h3>
+      <p className="mt-1 text-sm text-gray-600">
+        Tell us about your vehicle(s) and setup.
+      </p>
+
+      {/* location */}
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div>
+          <label className="block text-sm text-gray-700">City</label>
+          <input
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={meta.city}
+            onChange={(e) => setMeta((m) => ({ ...m, city: e.target.value }))}
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">State</label>
+          <input
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={meta.state}
+            onChange={(e) => setMeta((m) => ({ ...m, state: e.target.value }))}
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">ZIP</label>
+          <input
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={meta.zip5}
+            onChange={(e) => setMeta((m) => ({ ...m, zip5: e.target.value }))}
+          />
+        </div>
+      </div>
+
+      {/* vehicles */}
+      <div className="mt-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <h4 className="font-medium text-gray-900">Vehicle(s)</h4>
+          <button type="button" onClick={addRow} className="text-sm underline">
+            Add vehicle
+          </button>
+        </div>
+        {rows.map((row, i) => (
+          <div key={i} className="rounded-md border border-gray-200 p-3">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <input
+                placeholder="Year *"
+                value={row.year}
+                onChange={(e) => updateRow(i, "year", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+                required
+              />
+              <input
+                placeholder="Make *"
+                value={row.make}
+                onChange={(e) => updateRow(i, "make", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+                required
+              />
+              <input
+                placeholder="Model *"
+                value={row.model}
+                onChange={(e) => updateRow(i, "model", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+                required
+              />
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-4">
+              <select
+                value={row.bodyType}
+                onChange={(e) => updateRow(i, "bodyType", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+              >
+                {["Sedan", "SUV", "Truck", "Van", "EV", "Other"].map((v) => (
+                  <option key={v}>{v}</option>
+                ))}
+              </select>
+              <select
+                value={row.seats}
+                onChange={(e) => updateRow(i, "seats", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+              >
+                {["2", "4", "5", "6", "7", "8"].map((v) => (
+                  <option key={v}>{v}</option>
+                ))}
+              </select>
+              <select
+                value={row.transmission}
+                onChange={(e) => updateRow(i, "transmission", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+              >
+                {["Auto", "Manual"].map((v) => (
+                  <option key={v}>{v}</option>
+                ))}
+              </select>
+              <select
+                value={row.mileageBand}
+                onChange={(e) => updateRow(i, "mileageBand", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+              >
+                {["<50k", "50–100k", "100–150k", "150k+"].map((v) => (
+                  <option key={v}>{v}</option>
+                ))}
+              </select>
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+              <select
+                value={row.availability}
+                onChange={(e) => updateRow(i, "availability", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+              >
+                {["Weekdays", "Weekends", "Both"].map((v) => (
+                  <option key={v}>{v}</option>
+                ))}
+              </select>
+              <select
+                value={row.readiness}
+                onChange={(e) => updateRow(i, "readiness", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+              >
+                {["Ready now", "In 1–3 mo", "Just exploring"].map((v) => (
+                  <option key={v}>{v}</option>
+                ))}
+              </select>
+              <div className="flex justify-end">
+                {rows.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeRow(i)}
+                    className="text-sm text-red-600 underline"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* misc */}
+      <div className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div>
+          <label className="block text-sm text-gray-700">Insurance</label>
+          <select
+            value={meta.insuranceStatus}
+            onChange={(e) =>
+              setMeta((m) => ({ ...m, insuranceStatus: e.target.value }))
+            }
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+          >
+            <option value="personal">Personal</option>
+            <option value="commercial">Commercial</option>
+            <option value="unsure">Not sure</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">Handoff</label>
+          <select
+            value={meta.handoff}
+            onChange={(e) =>
+              setMeta((m) => ({ ...m, handoff: e.target.value }))
+            }
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+          >
+            <option value="in_person">In-person</option>
+            <option value="lockbox">Lockbox</option>
+            <option value="both">Both</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">Fleet size</label>
+          <select
+            value={meta.fleetSize}
+            onChange={(e) =>
+              setMeta((m) => ({ ...m, fleetSize: e.target.value }))
+            }
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+          >
+            <option value="1">1</option>
+            <option value="2_3">2–3</option>
+            <option value="4_9">4–9</option>
+            <option value="10_plus">10+</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <label className="block text-sm text-gray-700">
+          Pricing comfort (optional)
+        </label>
+        <input
+          placeholder="$ per night"
+          value={meta.pricingExpectation}
+          onChange={(e) =>
+            setMeta((m) => ({ ...m, pricingExpectation: e.target.value }))
+          }
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+        />
+      </div>
+      <div className="mt-3">
+        <label className="block text-sm text-gray-700">Notes</label>
+        <textarea
+          rows={3}
+          value={meta.notes}
+          onChange={(e) => setMeta((m) => ({ ...m, notes: e.target.value }))}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+        />
+      </div>
+
+      <div className="mt-5 flex items-center justify-between">
+        <div className="text-xs text-gray-500">
+          {savedAt
+            ? `Saved at ${savedAt.toLocaleTimeString()}`
+            : "Not saved yet"}
+        </div>
+        <Button type="submit" variant="primary" disabled={loading}>
+          {loading ? "Saving…" : "Save host details"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/forms/Step2Renter.js
+++ b/components/forms/Step2Renter.js
@@ -1,0 +1,249 @@
+// components/forms/Step2Renter.jsx
+"use client";
+import { useState } from "react";
+import Button from "@/components/ui/Button";
+
+export default function Step2Renter({ onSubmit, loading, savedAt }) {
+  const [pickup, setPickup] = useState({ city: "", state: "", zip5: "" });
+  const [dates, setDates] = useState({
+    earliestStart: "",
+    latestStart: "",
+    typicalDurationBand: "1-3",
+  });
+  const [prefs, setPrefs] = useState({
+    bodyType: "No preference",
+    seats: "5",
+    transmission: "No preference",
+    extras: [],
+  });
+  const [budgetBand, setBudgetBand] = useState("50_80");
+  const [ageBand, setAgeBand] = useState("25_plus");
+  const [notes, setNotes] = useState("");
+
+  function toggleExtra(x) {
+    setPrefs((p) =>
+      p.extras.includes(x)
+        ? { ...p, extras: p.extras.filter((e) => e !== x) }
+        : { ...p, extras: [...p.extras, x] }
+    );
+  }
+
+  function handleSave(e) {
+    e.preventDefault();
+    onSubmit({
+      pickup,
+      dates,
+      prefs: { ...prefs, seats: Number(prefs.seats || 0) },
+      budgetBand,
+      ageBand,
+      notes: notes?.trim() || undefined,
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="rounded-lg border border-gray-200 p-4"
+    >
+      <h3 className="text-lg font-semibold text-gray-900">Renter details</h3>
+      <p className="mt-1 text-sm text-gray-600">What you’re looking for.</p>
+
+      {/* pickup */}
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div>
+          <label className="block text-sm text-gray-700">City</label>
+          <input
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={pickup.city}
+            onChange={(e) => setPickup((p) => ({ ...p, city: e.target.value }))}
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">State</label>
+          <input
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={pickup.state}
+            onChange={(e) =>
+              setPickup((p) => ({ ...p, state: e.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">ZIP</label>
+          <input
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={pickup.zip5}
+            onChange={(e) => setPickup((p) => ({ ...p, zip5: e.target.value }))}
+          />
+        </div>
+      </div>
+
+      {/* when */}
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div>
+          <label className="block text-sm text-gray-700">Earliest start</label>
+          <input
+            type="date"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={dates.earliestStart}
+            onChange={(e) =>
+              setDates((d) => ({ ...d, earliestStart: e.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">Latest start</label>
+          <input
+            type="date"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={dates.latestStart}
+            onChange={(e) =>
+              setDates((d) => ({ ...d, latestStart: e.target.value }))
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">
+            Typical duration
+          </label>
+          <select
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={dates.typicalDurationBand}
+            onChange={(e) =>
+              setDates((d) => ({ ...d, typicalDurationBand: e.target.value }))
+            }
+          >
+            <option value="1-3">1–3 days</option>
+            <option value="4-7">4–7 days</option>
+            <option value="8+">8+ days</option>
+          </select>
+        </div>
+      </div>
+
+      {/* prefs */}
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div>
+          <label className="block text-sm text-gray-700">Body type</label>
+          <select
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={prefs.bodyType}
+            onChange={(e) =>
+              setPrefs((p) => ({ ...p, bodyType: e.target.value }))
+            }
+          >
+            {["Sedan", "SUV", "Truck", "Van", "EV", "No preference"].map(
+              (v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              )
+            )}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">Seats</label>
+          <select
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={prefs.seats}
+            onChange={(e) => setPrefs((p) => ({ ...p, seats: e.target.value }))}
+          >
+            {["2", "4", "5", "6", "7", "8"].map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">Transmission</label>
+          <select
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={prefs.transmission}
+            onChange={(e) =>
+              setPrefs((p) => ({ ...p, transmission: e.target.value }))
+            }
+          >
+            {["Auto", "Manual", "No preference"].map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="mt-3">
+        <label className="block text-sm text-gray-700">Extras</label>
+        <div className="mt-2 flex flex-wrap gap-3 text-sm">
+          {[
+            "Car seat",
+            "Ski rack",
+            "Bike rack",
+            "Snow tires",
+            "No preference",
+          ].map((x) => (
+            <label key={x} className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={prefs.extras.includes(x)}
+                onChange={() => toggleExtra(x)}
+              />
+              {x}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* budget / age */}
+      <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div>
+          <label className="block text-sm text-gray-700">
+            Budget (per day)
+          </label>
+          <select
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={budgetBand}
+            onChange={(e) => setBudgetBand(e.target.value)}
+          >
+            <option value="<50">&lt; $50</option>
+            <option value="50_80">$50–$80</option>
+            <option value="80_120">$80–$120</option>
+            <option value="120_plus">$120+</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700">Age band</label>
+          <select
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+            value={ageBand}
+            onChange={(e) => setAgeBand(e.target.value)}
+          >
+            <option value="u21">Under 21</option>
+            <option value="21_24">21–24</option>
+            <option value="25_plus">25+</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <label className="block text-sm text-gray-700">Notes</label>
+        <textarea
+          rows={3}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+        />
+      </div>
+
+      <div className="mt-5 flex items-center justify-between">
+        <div className="text-xs text-gray-500">
+          {savedAt
+            ? `Saved at ${savedAt.toLocaleTimeString()}`
+            : "Not saved yet"}
+        </div>
+        <Button type="submit" variant="primary" disabled={loading}>
+          {loading ? "Saving…" : "Save renter details"}
+        </Button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
…1Quick step usage

Step1Quick: drop status prop and local status render; no step reference

LeadForm: shell now solely owns status (aria-live=polite) for POST & PATCH

Keeps UX identical; prevents undefined step errors; reduces prop churn

Minor tidy: only pass role, setRole, onSubmit, loading to Step1Quick