### PR TITLE
feat(leadform): UX polish + data capture

### DIFF
--- a/components/forms/Step1Quick.js
+++ b/components/forms/Step1Quick.js
@@ -4,7 +4,7 @@ import { useRef } from "react";
 import Button from "../ui/Button";
 
 export default function Step1Quick({
-  role,            // 'host' | 'renter' | 'both'
+  role, // 'host' | 'renter' | 'both'
   setRole,
   onSubmit,
   loading,
@@ -19,6 +19,7 @@ export default function Step1Quick({
       // pretend success to bots
       onSubmit({
         firstName: "Bot",
+        lastName: "Bot",
         email: "bot@example.com",
         phone: "",
         cityOrZip: "",
@@ -29,33 +30,56 @@ export default function Step1Quick({
     }
     onSubmit({
       firstName: fd.get("firstName"),
+      lastName: fd.get("lastName"),
       email: fd.get("email"),
       phone: fd.get("phone"),
       cityOrZip: fd.get("cityOrZip"),
       consent: fd.get("consent") === "on",
       honeypot: fd.get("website") || "",
     });
-    try { formRef.current?.reset(); } catch {}
+    try {
+      formRef.current?.reset();
+    } catch {}
   }
 
   return (
     <form ref={formRef} onSubmit={handleSubmit} className="space-y-4">
       {/* name / email */}
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
         <div>
           <label className="block text-sm text-gray-700">First name *</label>
-          <input name="firstName" required className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+          <input
+            name="firstName"
+            required
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm text-gray-700">Last name</label>{" "}
+          <input
+            name="lastName"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+          />{" "}
         </div>
         <div>
           <label className="block text-sm text-gray-700">Email *</label>
-          <input type="email" name="email" required className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+          <input
+            type="email"
+            name="email"
+            required
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+          />
         </div>
       </div>
 
       {/* phone */}
       <div>
         <label className="block text-sm text-gray-700">Phone (optional)</label>
-        <input name="phone" className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2" />
+        <input
+          name="phone"
+          className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2"
+        />
       </div>
 
       {/* city or zip */}
@@ -71,14 +95,19 @@ export default function Step1Quick({
 
       {/* role picker */}
       <fieldset className="mt-1">
-        <legend className="block text-sm text-gray-700">I’m interested as *</legend>
+        <legend className="block text-sm text-gray-700">
+          I’m interested as *
+        </legend>
         <div className="mt-2 flex flex-wrap gap-3">
           {[
             { value: "host", label: "Host" },
             { value: "renter", label: "Renter" },
             { value: "both", label: "Both" },
           ].map((opt) => (
-            <label key={opt.value} className="inline-flex items-center gap-2 text-sm text-gray-800">
+            <label
+              key={opt.value}
+              className="inline-flex items-center gap-2 text-sm text-gray-800"
+            >
               <input
                 type="radio"
                 name="role"
@@ -94,9 +123,18 @@ export default function Step1Quick({
 
       {/* consent */}
       <div className="flex items-center gap-2">
-        <input id="consent" name="consent" type="checkbox" required className="h-4 w-4" />
+        <input
+          id="consent"
+          name="consent"
+          type="checkbox"
+          required
+          className="h-4 w-4"
+        />
         <label htmlFor="consent" className="text-sm text-gray-700">
-          I agree to be contacted about FR. <a href="/legal/privacy" className="underline">Privacy Policy</a>
+          I agree to be contacted about FR.{" "}
+          <a href="/legal/privacy" className="underline">
+            Privacy Policy
+          </a>
         </label>
       </div>
 

--- a/components/forms/Step2Host.js
+++ b/components/forms/Step2Host.js
@@ -2,21 +2,23 @@
 "use client";
 import { useState } from "react";
 import Button from "../ui/Button";
+import { useEffect, useState } from "react";
 
-export default function Step2Host({ onSubmit, loading, savedAt }) {
-  const [rows, setRows] = useState([
-    {
-      year: "",
-      make: "",
-      model: "",
-      bodyType: "Sedan",
-      seats: "5",
-      transmission: "Auto",
-      mileageBand: "<50k",
-      availability: "Both",
-      readiness: "Ready now",
-    },
-  ]);
+export default function Step2Host({ onSubmit, loading, savedAt, resetSignal }) {
+  const initialRow = {
+    year: "",
+    make: "",
+    model: "",
+    bodyType: "Sedan",
+    seats: "5",
+    transmission: "Auto",
+    mileageBand: "<50k",
+    availability: "Both",
+    readiness: "Ready now",
+    condition: "Good",
+  };
+  const [rows, setRows] = useState([initialRow]);
+
   const [meta, setMeta] = useState({
     city: "",
     state: "",
@@ -28,21 +30,24 @@ export default function Step2Host({ onSubmit, loading, savedAt }) {
     notes: "",
   });
 
+  useEffect(() => {
+    if (resetSignal != null) {
+      setRows([initialRow]);
+      setMeta({
+        city: "",
+        state: "",
+        zip5: "",
+        insuranceStatus: "unsure",
+        handoff: "both",
+        pricingExpectation: "",
+        fleetSize: "1",
+        notes: "",
+      });
+    }
+  }, [resetSignal]);
+
   function addRow() {
-    setRows((r) => [
-      ...r,
-      {
-        year: "",
-        make: "",
-        model: "",
-        bodyType: "Sedan",
-        seats: "5",
-        transmission: "Auto",
-        mileageBand: "<50k",
-        availability: "Both",
-        readiness: "Ready now",
-      },
-    ]);
+    setRows((r) => [...r, { ...initialRow }]);
   }
   function removeRow(i) {
     setRows((r) => r.filter((_, idx) => idx !== i));
@@ -61,6 +66,7 @@ export default function Step2Host({ onSubmit, loading, savedAt }) {
       seats: Number(r.seats || 0),
       transmission: r.transmission,
       mileageBand: r.mileageBand,
+      condition: r.condition,
       availability: r.availability,
       readiness: r.readiness,
     }));
@@ -193,7 +199,7 @@ export default function Step2Host({ onSubmit, loading, savedAt }) {
                 ))}
               </select>
             </div>
-            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+            <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-4">
               <select
                 value={row.availability}
                 onChange={(e) => updateRow(i, "availability", e.target.value)}
@@ -209,6 +215,15 @@ export default function Step2Host({ onSubmit, loading, savedAt }) {
                 className="rounded-md border border-gray-300 px-3 py-2"
               >
                 {["Ready now", "In 1–3 mo", "Just exploring"].map((v) => (
+                  <option key={v}>{v}</option>
+                ))}
+              </select>
+              <select
+                value={row.condition}
+                onChange={(e) => updateRow(i, "condition", e.target.value)}
+                className="rounded-md border border-gray-300 px-3 py-2"
+              >
+                {["Excellent", "Good", "Fair"].map((v) => (
                   <option key={v}>{v}</option>
                 ))}
               </select>

--- a/components/forms/Step2Renter.js
+++ b/components/forms/Step2Renter.js
@@ -1,9 +1,14 @@
 // components/forms/Step2Renter.jsx
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "@/components/ui/Button";
 
-export default function Step2Renter({ onSubmit, loading, savedAt }) {
+export default function Step2Renter({
+  onSubmit,
+  loading,
+  savedAt,
+  resetSignal,
+}) {
   const [pickup, setPickup] = useState({ city: "", state: "", zip5: "" });
   const [dates, setDates] = useState({
     earliestStart: "",
@@ -19,6 +24,26 @@ export default function Step2Renter({ onSubmit, loading, savedAt }) {
   const [budgetBand, setBudgetBand] = useState("50_80");
   const [ageBand, setAgeBand] = useState("25_plus");
   const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    if (resetSignal != null) {
+      setPickup({ city: "", state: "", zip5: "" });
+      setDates({
+        earliestStart: "",
+        latestStart: "",
+        typicalDurationBand: "1-3",
+      });
+      setPrefs({
+        bodyType: "No preference",
+        seats: "5",
+        transmission: "No preference",
+        extras: [],
+      });
+      setBudgetBand("50_80");
+      setAgeBand("25_plus");
+      setNotes("");
+    }
+  }, [resetSignal]);
 
   function toggleExtra(x) {
     setPrefs((p) =>

--- a/components/ui/Modal.js
+++ b/components/ui/Modal.js
@@ -1,0 +1,30 @@
+// components/ui/Modal.tsx
+"use client";
+import { useEffect } from "react";
+
+export default function Modal({ open, title, children, onClose, actionLabel, onAction }) {
+  useEffect(() => {
+    function onEsc(e) { if (e.key === "Escape") onClose?.(); }
+    if (open) document.addEventListener("keydown", onEsc);
+    return () => document.removeEventListener("keydown", onEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative w-full max-w-md rounded-lg bg-white p-5 shadow-xl">
+        <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+        <div className="mt-3 text-sm text-gray-700">{children}</div>
+        <div className="mt-5 flex justify-end gap-3">
+          <button className="rounded-md border px-3 py-1.5 text-sm" onClick={onClose}>Close</button>
+          {onAction && (
+            <button className="rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white" onClick={onAction}>
+              {actionLabel || "OK"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Step1Quick: add Last name; keep shell-owned status; still clears on submit
- LeadForm: add headless Modal; Step 1 success shows CTA (“Skip the line”) to open Step 2; Step 2 success shows “Done” modal that refreshes; adds resetSignal to clear Step 2 forms
- Step2Host: add per-vehicle  (Excellent/Good/Fair); supports resetSignal
- Step2Renter: supports resetSignal to clear after save
- Reco: use NHTSA vPIC API with React Select (async) for make/model/year (avoids stale npm datasets)